### PR TITLE
Fixing GUI Dependency

### DIFF
--- a/environment_staging.yml
+++ b/environment_staging.yml
@@ -126,7 +126,7 @@ dependencies:
       - pyqt5-sip==12.13.0
       - pyrealsense2==2.54.2.5684
       - pyserial==3.5
-      - pysimplegui==4.60.5
+      - FreeSimpleGUI==5.2.0.post1
       - python-bidi==0.4.2
       - python-dateutil==2.8.2
       - python-gitlab==4.1.1
@@ -163,4 +163,3 @@ dependencies:
       - git+https://github.com/neurobooth/neurobooth-terra.git#egg=neurobooth_terra
       - h5py==3.10.0
       - h5io==0.2.1
-prefix: C:\Users\lw412\anaconda3\envs\neurobooth-staging

--- a/neurobooth_os/gui.py
+++ b/neurobooth_os/gui.py
@@ -15,9 +15,9 @@ from typing import Dict, Optional, List
 import cv2
 import numpy as np
 
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import liesl
-from PySimpleGUI import Multiline
+from FreeSimpleGUI import Multiline
 
 import neurobooth_os.main_control_rec as ctr_rec
 from neurobooth_os.realtime.lsl_plotter import create_lsl_inlets, stream_plotter

--- a/neurobooth_os/layouts.py
+++ b/neurobooth_os/layouts.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import os.path as op
 import numpy as np
 
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import cv2
 
 import neurobooth_os.iout.metadator as meta


### PR DESCRIPTION
PySimpleGUI has sunset version 4 and the the project itself was ended. This PR updates the environment dependencies to use FreeSimpleGUI, a drop-in replacement. Version 5 should be backwards compatible, though testing will be needed.

Note that git may need to be added to the conda dependencies if not install on the system path.

Also note that pylink and neurobooth-os itself need to be separately installed via pip.